### PR TITLE
Expose Groq base URL env var

### DIFF
--- a/server.py
+++ b/server.py
@@ -73,6 +73,7 @@ GATEKEEPER_CONTENT_PACK: str = (
 
 llm = GroqLLMService(
     api_key=os.getenv("GROQ_API_KEY"),
+    base_url=os.getenv("GROQ_API_BASE", "https://api.groq.com/openai/v1"),
     model=os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile"),
     system_message=(
         GATEKEEPER_CONTENT_PACK


### PR DESCRIPTION
## Summary
- allow overriding Groq API endpoint via `GROQ_API_BASE`

## Testing
- `python -m py_compile script_gate.py server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7629b7dac832dbe2a971235c15b67